### PR TITLE
プレイリストの一覧読み込みとその他軽微な修正

### DIFF
--- a/os/app/GNUmakefile
+++ b/os/app/GNUmakefile
@@ -24,5 +24,5 @@
 # 2020.08.23 : 新規
 #
 
-OBJS= spi.o font.o lcd.o mp3Proc.o shellProc.o appUtil.o mp3Files.o screenState.o option.o
+OBJS= spi.o font.o lcd.o mp3Proc.o shellProc.o appUtil.o mp3Files.o screenState.o option.o playList.o
 include ../Makefile.rul

--- a/os/app/mp3Files.cmm
+++ b/os/app/mp3Files.cmm
@@ -34,10 +34,10 @@
 
 
 //-----------------------------------------------------------------------------
-// MP3ファイルの一覧（ただし，最大1５個）
+// MP3ファイルの一覧（ただし，最大30個）
 //-----------------------------------------------------------------------------
-#define MAX_FILE 15
-// 1５つのファイル名
+#define MAX_FILE 30
+//30個のファイル名
 char[][] fnames = array(MAX_FILE, 13);                     // 12345678.123
 int numFile;                                        // ファイルの個数
 
@@ -61,6 +61,7 @@ public void mp3FilesInit() {
   int i = 0;
   while (i<MAX_FILE && (dir=readDir(fd, "MP3"))!=null) {   // 最大15つファイル名を読む
     strCpy(fnames[i], dir.name);
+    dbgPutStr("Read music\n");
     i = i + 1;
   }
   numFile = i;
@@ -83,7 +84,7 @@ public char[] mp3FilesGetPath(int n) {
   return null;
 }
 
-// MP3フォルダ内にあるファイルの総数を返す（最大15ファイルまで対応）
+// MP3フォルダ内にあるファイルの総数を返す（最大30ファイルまで対応）
 public int mp3FilesGetTotalNum() {
   return numFile;
 }

--- a/os/app/playList.cmm
+++ b/os/app/playList.cmm
@@ -56,6 +56,23 @@ public void playListInit() {
     i = i + 1;
   }
   close(fd);
+  //リスト番号を整理して01→10で並び替える，単純なバブルソート
+  int p = 0;
+  int q = LIST_NUM - 1;
+  while (p < LIST_NUM) {
+    q = LIST_NUM - 1; //qの初期化 
+    while (q > p) {
+        if (strCmp(fnames[q - 1], fnames[q]) > 0) {
+            char [] tmp =  malloc(13); //ソートのための一時待避所
+            strCpy(tmp, fnames[q - 1]);
+            strCpy(fnames[q - 1], fnames[q]);
+            strCpy(fnames[q], tmp);
+            free(tmp);
+        }
+        q =  q - 1; // 比較要素の更新
+    }
+    p = p + 1; //確定要素の更新
+  }
 }
 
 // n 番目ファイル名を返す（1<=n && n<=LIST_NUM）
@@ -63,7 +80,7 @@ public char[] playListGetName(int n) {
   if (1<=n && n<=LIST_NUM) {
     //リストは".txt"を消して表示させる．
     char[] list_fnames = malloc(13);     // 表示用バッファの確保
-    strCpy(list_fnames, fnames[n - 1]);  // 文字列をコピーする
+    strCpy(list_fnames, fnames[n - 1]);  // list_fname に fnames[n - 1] をコピーする
     //拡張子"."が来るまで読み込む
     int idx = 0;
     while(list_fnames[idx] != '.' && list_fnames[idx] != '\0') {

--- a/os/app/playList.cmm
+++ b/os/app/playList.cmm
@@ -1,34 +1,84 @@
+/*
+ * TacOS Source Code
+ *    Tokuyama kousen Advanced educational Computer.
+ *
+ * Copyright (C) 2020 by
+ *                      Dept. of Computer Science and Electronic Engineering,
+ *                      Tokuyama College of Technology, JAPAN
+ *
+ *   上記著作権者は，Free Software Foundation によって公開されている GNU 一般公
+ * 衆利用許諾契約書バージョン２に記述されている条件を満たす場合に限り，本ソース
+ * コード(本ソースコードを改変したものを含む．以下同様)を使用・複製・改変・再配
+ * 布することを無償で許諾する．
+ *
+ *   本ソースコードは＊全くの無保証＊で提供されるものである。上記著作権者および
+ * 関連機関・個人は本ソースコードに関して，その適用可能性も含めて，いかなる保証
+ * も行わない．また，本ソースコードの利用により直接的または間接的に生じたいかな
+ * る損害に関しても，その責任を負わない．
+ *
+ * This programming code was procuded by CE2.
+ */
+
 #include "playList.hmm"
 #include "mp3Files.hmm"
+#include <fs.hmm>
+#include <util.hmm>
+#include "appUtil.hmm"
+#include "mm.hmm"
 
+#define LIST_NUM 10 //プレイリストは10個で固定する
 
-char[][] playList = array(50); // 最大曲数は仮に50曲
-int listSize = 0;              // リスト内の現在曲数を保持する
-int cursNum = 0;               // カーソルで選択した曲のインデクスを管理
+char[][] playList = array(50); // 1つのプレイリストに登録できる最大曲数は仮に50曲
 
 char[][] fnames = array(10, 13);                     // 12345678.123
-int numFile;                                        // ファイルの個数
 
-char[] mp3Dir = "/playlist";
-char[] path = array(23);                            // /playlist/12345678.123
+char[] playlistDir = "/playlist";
+char[] path = array(18);                            // /playlist/12345678.123
 
 char[] fnameToPath(char[] fname) {
-  strCpy(path, mp3Dir);
+  strCpy(path, playlistDir);
   strCat(path, "/");
   strCat(path, fname);
   return path;
 }
 
 // プレイリストの一覧を表示する．
-public void showlist() {
-
+public void playListInit() {
+  int fd;                                           // ファイルディスクリプタ
+  if ((fd=open(playlistDir, READ_MODE))<0) {
+    panic("panic:can't open playList Dir");
+  }
+  Dir dir;
+  int i = 0;
+  while (i< LIST_NUM && (dir=readDir(fd, "TXT"))!=null) {   // 最大10つファイル名を読む
+    strCpy(fnames[i], dir.name);
+    dbgPutStr("Read PlayList\n");
+    i = i + 1;
+  }
+  close(fd);
 }
 
-// プレイリストに曲を追加する．
-public void addFile() {
-    if (listSize >= playList.length) return;
-    for (int i = 0, i < mp3FilesGetNum(); i++) {
-        //パスをプレイリストに追加する．
-        playList[listSize++] = mp3FilesGetPath(i);
+// n 番目ファイル名を返す（1<=n && n<=LIST_NUM）
+public char[] playListGetName(int n) {
+  if (1<=n && n<=LIST_NUM) {
+    //リストは".txt"を消して表示させる．
+    char[] list_fnames = malloc(13);     // 表示用バッファの確保
+    strCpy(list_fnames, fnames[n - 1]);  // 文字列をコピーする
+    //拡張子"."が来るまで読み込む
+    int idx = 0;
+    while(list_fnames[idx] != '.' && list_fnames[idx] != '\0') {
+        idx = idx + 1;
     }
+    list_fnames[idx] = '\0'; 
+    return list_fnames;
+  }
+  return null;
+}
+
+// n 番目パス名を返す（1<=n && n<=LIST_NUM）
+public char[] playListGetPath(int n) {
+  if (1<=n && n<=LIST_NUM) {
+    return fnameToPath(fnames[n-1]);
+  }
+  return null;
 }

--- a/os/app/playList.hmm
+++ b/os/app/playList.hmm
@@ -1,0 +1,33 @@
+/*
+ * TacOS Source Code
+ *    Tokuyama kousen Advanced educational Computer.
+ *
+ * Copyright (C) 2020 by
+ *                      Dept. of Computer Science and Electronic Engineering,
+ *                      Tokuyama College of Technology, JAPAN
+ *
+ *   上記著作権者は，Free Software Foundation によって公開されている GNU 一般公
+ * 衆利用許諾契約書バージョン２に記述されている条件を満たす場合に限り，本ソース
+ * コード(本ソースコードを改変したものを含む．以下同様)を使用・複製・改変・再配
+ * 布することを無償で許諾する．
+ *
+ *   本ソースコードは＊全くの無保証＊で提供されるものである。上記著作権者および
+ * 関連機関・個人は本ソースコードに関して，その適用可能性も含めて，いかなる保証
+ * も行わない．また，本ソースコードの利用により直接的または間接的に生じたいかな
+ * る損害に関しても，その責任を負わない．
+ *
+ *
+ */
+
+/*
+ * playList.hmm : プレイリストの一覧
+ *
+ * 2020.09.16 : 新規作成
+ *
+ * $Id$
+ *
+ */
+
+public void playListInit();               // プレイリストの初期化
+public char[] playListGetName(int n);
+public char[] playListGetPath(int n);

--- a/os/app/shellProc.cmm
+++ b/os/app/shellProc.cmm
@@ -37,6 +37,7 @@
 #include "screenState.hmm"
 #include "mm.hmm"
 #include "option.hmm"
+#include "playList.hmm"
 
 
 //-----------------------------------------------------------------------------
@@ -52,7 +53,7 @@
 #define SWS 0x3f                                    // スイッチのビット全部
 
 //-----------------------------------------------------------------------------
-//画面ごとの番号定義 0:ホーム　1：曲一覧　2：再生画面　3：オプション　4：プレイリスト
+//画面ごとの番号定義 0:ホーム　1：曲一覧　2：再生画面　3：オプション　4：音量調整　5：コントラスト調整　6.プレイリスト
 //-----------------------------------------------------------------------------
 #define HOME_STATE 0
 #define MUSIC_STATE 1
@@ -66,6 +67,7 @@
 #define NAME_LEN 16
 
 char[][] musicList;
+char[][] playList;
 
 int sw0 = 0x00;                                     // 前回の状態(デバウンス前)
 int sw1 = 0x00;                                     // 前回の状態(デバウンス後)
@@ -154,6 +156,36 @@ void free_musiclist(){
     free(musicList);
 }
 
+//-----------------------------------------
+//プレイリスト覧用のメモリ確保
+//-----------------------------------------
+void malloc_playlist(int upper_idx){
+  playList = malloc(MAX_LIST * 4);
+    int i = 0;
+    while (i < MAX_LIST) {
+      playList[i] = malloc(NAME_LEN);
+      char[] fname = playListGetName(i + upper_idx + 1);
+      if (fname != null) {
+        strCpy(playList[i], fname);
+      } else {
+        playList[i][0] = '\0';
+      }
+      i = i + 1;
+    }
+}
+
+//-----------------------------------------
+//プレイリスト一覧用のメモリ解放
+//-----------------------------------------
+void free_playlist(){
+  int i = 0;
+    while (i < MAX_LIST) {
+      free(playList[i]);
+      i = i + 1;
+    }
+    free(playList);
+}
+
 //-----------------------------------------------------------------------------
 // MP3 プレーヤのメインプロセス
 //-----------------------------------------------------------------------------
@@ -162,6 +194,7 @@ public void shellMain() {
   spiResetLcd();  // sleepを使用するので
   spiResetMp3();  //   プロセスが実行する
   mp3FilesInit();  // ファイル一覧を作る
+  playListInit(); // プレイリストの一覧を作る
   initScreens();
 
   int state = HOME_STATE;
@@ -169,6 +202,7 @@ public void shellMain() {
   int cursorPos = 0;
   int music_idx = 0;
   int list_upper = 0; //リスト表示される要素の最上のインデクスを保持する．
+  int music_select_cursor = 0;
   showScreen(state, cursorPos);
 
   //メインプロセスのループ
@@ -189,9 +223,17 @@ public void shellMain() {
           list_upper = list_upper - 1;
           free_musiclist();
           malloc_musiclist(list_upper);
-          setScreenMenuItems(MUSIC_STATE, musicList, MAX_LIST);
+          setScreenMenuItems(state, musicList, MAX_LIST);
         }
-      } else {
+      } else if (state == PLAYLIST_STATE){
+        //プレイリスト画面で，かつ上端まで来たときの処理
+        if (cursorPos == 0 && list_upper > 0) {
+          list_upper = list_upper - 1;
+          free_playlist();
+          malloc_playlist(list_upper);
+          setScreenMenuItems(state, playList, MAX_LIST);
+        }
+      }else {
         // 項目数が6以下のとき：ループ処理
         cursorPos = numItems - 1;
         }
@@ -209,9 +251,17 @@ public void shellMain() {
           list_upper = list_upper + 1;
           free_musiclist();
           malloc_musiclist(list_upper);
-          setScreenMenuItems(MUSIC_STATE, musicList, MAX_LIST);
+          setScreenMenuItems(state, musicList, MAX_LIST);
         }
-      }  else {
+      }  else if (state == PLAYLIST_STATE) {
+        //プレイリスト画面で，かつ下端まで来たときのスクロール処理
+        if (cursorPos + list_upper < 9) {
+          list_upper = list_upper + 1;
+          free_playlist();
+          malloc_playlist(list_upper);
+          setScreenMenuItems(state, playList, MAX_LIST);
+        }
+      } else {
         //下端→上端ループ
         cursorPos = 0;
         list_upper = 0;
@@ -232,13 +282,20 @@ public void shellMain() {
         } else {
           //PlayListを押した場合
           cursorPos=0;
-          showScreen(PLAYLIST_STATE,cursorPos);
+          list_upper = 0;
+          state = PLAYLIST_STATE;
+          int numlist = getScreenNumItems(state);
+
+          malloc_playlist(list_upper);
+          setScreenMenuItems(state, playList, numlist);
+          showScreen(state, cursorPos);
         }
       }
       else if (state == MUSIC_STATE) {
         char[] selectedTitle = malloc(NAME_LEN);
         music_idx = cursorPos + list_upper +1;
         char[] fname = mp3FilesGetName(music_idx);
+        music_select_cursor = cursorPos;
         
         if (fname != null) {
           strCpy(selectedTitle, fname);
@@ -298,7 +355,7 @@ public void shellMain() {
       }
       else if (state == MUSIC_INF) {
         state = MUSIC_STATE;
-        cursorPos = 0;
+        cursorPos = music_select_cursor;
         showScreen(state, cursorPos);
       }
       else if (state == VOLUME_STATE) {
@@ -308,6 +365,11 @@ public void shellMain() {
       }
       else if (state == CONTRAST_STATE) {
         state = OPTION_STATE;
+        cursorPos = 0;
+        showScreen(state, cursorPos);
+      }
+      else if (state == PLAYLIST_STATE) {
+        state = HOME_STATE;
         cursorPos = 0;
         showScreen(state, cursorPos);
       }

--- a/os/app/shellProc.cmm
+++ b/os/app/shellProc.cmm
@@ -68,7 +68,7 @@
 
 char[][] musicList;
 char[][] playList;
-int[] prevcursor = array(10);
+int[] prevcursor = array(15);                       // カーソル情報を保持する変数
 
 int sw0 = 0x00;                                     // 前回の状態(デバウンス前)
 int sw1 = 0x00;                                     // 前回の状態(デバウンス後)

--- a/os/app/shellProc.cmm
+++ b/os/app/shellProc.cmm
@@ -68,6 +68,7 @@
 
 char[][] musicList;
 char[][] playList;
+int[] prevcursor = array(10);
 
 int sw0 = 0x00;                                     // 前回の状態(デバウンス前)
 int sw1 = 0x00;                                     // 前回の状態(デバウンス後)
@@ -202,7 +203,7 @@ public void shellMain() {
   int cursorPos = 0;
   int music_idx = 0;
   int list_upper = 0; //リスト表示される要素の最上のインデクスを保持する．
-  int music_select_cursor = 0;
+
   showScreen(state, cursorPos);
 
   //メインプロセスのループ
@@ -237,6 +238,7 @@ public void shellMain() {
         // 項目数が6以下のとき：ループ処理
         cursorPos = numItems - 1;
         }
+        prevcursor[state] = cursorPos; //カーソル情報の保持
         showScreen(state, cursorPos);
     }
     else if (num == 5) {  // SW5 = 下
@@ -266,6 +268,7 @@ public void shellMain() {
         cursorPos = 0;
         list_upper = 0;
       }
+      prevcursor[state] = cursorPos;
       showScreen(state, cursorPos);
     }
 
@@ -295,7 +298,6 @@ public void shellMain() {
         char[] selectedTitle = malloc(NAME_LEN);
         music_idx = cursorPos + list_upper +1;
         char[] fname = mp3FilesGetName(music_idx);
-        music_select_cursor = cursorPos;
         
         if (fname != null) {
           strCpy(selectedTitle, fname);
@@ -350,27 +352,27 @@ public void shellMain() {
     else if (num == 2) { // SW2 = 戻る
       if (state == MUSIC_STATE) {
         state = HOME_STATE;
-        cursorPos = 0;
+        cursorPos = prevcursor[state];
         showScreen(state, cursorPos);
       }
       else if (state == MUSIC_INF) {
         state = MUSIC_STATE;
-        cursorPos = music_select_cursor;
+        cursorPos = prevcursor[state];
         showScreen(state, cursorPos);
       }
       else if (state == VOLUME_STATE) {
         state = OPTION_STATE;
-        cursorPos = 0;
+        cursorPos = prevcursor[state];
         showScreen(state, cursorPos);
       }
       else if (state == CONTRAST_STATE) {
         state = OPTION_STATE;
-        cursorPos = 0;
+        cursorPos = prevcursor[state];
         showScreen(state, cursorPos);
       }
       else if (state == PLAYLIST_STATE) {
         state = HOME_STATE;
-        cursorPos = 0;
+        cursorPos = prevcursor[state];
         showScreen(state, cursorPos);
       }
     }
@@ -378,14 +380,14 @@ public void shellMain() {
     else if (num == 6) { // SW6 = OPTION 画面の出入り
       if (state == VOLUME_STATE || state == CONTRAST_STATE) {
         state = prevState;
-        cursorPos = 0;
+        cursorPos = prevcursor[state];
         showScreen(state, cursorPos);
       }
       else if (state == OPTION_STATE) {
         state = prevState;      // OPTIONに入る前の状態を記録
-        cursorPos = 0;
-        showScreen(state, cursorPos);   // OPTION画面へ
-      } else {
+        cursorPos = prevcursor[state];
+        showScreen(state, cursorPos); 
+      } else { //OPTION画面に入る．
         prevState = state;
         state = OPTION_STATE;
         cursorPos = 0;

--- a/os/util/util.cmm
+++ b/os/util/util.cmm
@@ -312,7 +312,7 @@ public void utilInit() {
   MEM = _ItoA(0);                                   // MEMは0x0000を指すchar型
   WMEM = _ItoA(0);
 #ifdef DEBUG
-  ftFlag = false;                                   // デバッグモードでは
+  ftFlag = true;                                   // デバッグモードでは
   rnFlag = ((in(0x2e) & 3)!=0);                     //   メッセージが多いので
                                                     //    bluetooth だけに出力
 #else


### PR DESCRIPTION
playlistフォルダをSD直下に作成し，次のようにファイルを定義することで一覧を表示できます．

！！拡張子はtxtとしてください．コードでtxtファイルを読むように指定しています．！！
※ ファイルの表示は必ずしも昇順になりません．おそらく更新日時順に読み込んでいる？

また，MUSIC_STATE (決定) → MUSIC_INF  (戻る) → MUSIC_STATE　と遷移した際に CursorPos が一番上まで戻る現象を修正しました．もとの CursorPos の位置となるように調整しています．

※２ util/util.cmm の debug はいずれ false にしたほうがよいかもしれません．秒数の表示に悪影響がありそうです．

--
SD
 |
playlist
 L  list01.txt
     list02.txt
          ・
          ・
          ・
     list10.txt