### PR TITLE
プレイリストへの曲追加，曲削除機能の実装とその他修正

### DIFF
--- a/os/app/lcd.cmm
+++ b/os/app/lcd.cmm
@@ -37,6 +37,7 @@
 
 #define MAX_FILE 50
 int[] addIdx = array(MAX_FILE); // 追加曲用のidx
+int[] delIdx = array(MAX_FILE); // 削除曲用のidx
 
 char[] locateCom = { '\xb0',   // page address
                      '\x10',   // column address Hi = 0x00
@@ -161,4 +162,30 @@ public int getAddIdx(int m) { // 引数 cursorPos + list_upper + 1
 
 public int[] getAllAddIdx() {
   return addIdx;
+}
+
+public void showDelSongs(int m, int n) {
+  locateXY(3,m+1);
+  putStr("-");
+  delIdx[n-1] = 1;
+}
+
+public void showDelSongsClear(int m, int n) {
+  locateXY(3,m+1);
+  putStr(" ");
+  delIdx[n-1] = 0;
+}
+
+public void delIdxInit() {
+  for (int i = 0; i < MAX_FILE; i = i + 1) {
+    delIdx[i] = 0;
+  }
+}
+
+public int getDelIdx(int m) {
+  return delIdx[m-1];
+}
+
+public int[] getAllDelIdx() {
+  return delIdx;
 }

--- a/os/app/lcd.cmm
+++ b/os/app/lcd.cmm
@@ -35,6 +35,9 @@
 #include "font.hmm"
 #include "lcd.hmm"
 
+#define MAX_FILE 50
+int[] addIdx = array(MAX_FILE); // 追加曲用のidx
+
 char[] locateCom = { '\xb0',   // page address
                      '\x10',   // column address Hi = 0x00
                      '\x00',   // column address Lo = 0x00
@@ -131,4 +134,31 @@ public void showShuffleClear() {
 public void showShuffleTrue() {
   locateXY(12,6);
   putStr("<->");
+}
+
+public void showAddSongs(int m, int n) {  // 第一引数　cursorPos, 第二引数 cursorPos + list_upper + 1
+  locateXY(3,m+1);
+  putStr("+");
+  addIdx[n-1] = 1;
+}
+
+public void showAddSongsClear(int m, int n) {
+  locateXY(3,m+1);
+  putStr(" ");
+  addIdx[n-1] = 0;
+}
+
+public void addIdxInit() {
+  for (int i = 0; i < MAX_FILE; i = i + 1) {
+    addIdx[i] = 0;
+  }
+}
+
+// m 番目の"+"選択状態を返す
+public int getAddIdx(int m) { // 引数 cursorPos + list_upper + 1
+  return addIdx[m-1];
+}
+
+public int[] getAllAddIdx() {
+  return addIdx;
 }

--- a/os/app/lcd.hmm
+++ b/os/app/lcd.hmm
@@ -42,3 +42,8 @@ public void showAddSongsClear(int m, int n);
 public void addIdxInit();
 public int getAddIdx(int m);
 public int[] getAllAddIdx();
+public void showDelSongs(int m, int n);
+public void showDelSongsClear(int m, int n);
+public void delIdxInit();
+public int getDelIdx(int m);
+public int[] getAllDelIdx();

--- a/os/app/lcd.hmm
+++ b/os/app/lcd.hmm
@@ -37,3 +37,8 @@ public void showRepeatOne();
 public void showRepeatAll();
 public void showShuffleClear();
 public void showShuffleTrue();
+public void showAddSongs(int m, int n);
+public void showAddSongsClear(int m, int n);
+public void addIdxInit();
+public int getAddIdx(int m);
+public int[] getAllAddIdx();

--- a/os/app/mp3Files.cmm
+++ b/os/app/mp3Files.cmm
@@ -71,7 +71,6 @@ public void mp3FilesInit() {
   int i = 0;
   while (i<MAX_FILE && (dir=readDir(fd, "MP3"))!=null) {   // 最大15つファイル名を読む
     strCpy(fnames[i], dir.name);
-    dbgPutStr("Read music\n");
     i = i + 1;
   }
   numFile = i;
@@ -93,6 +92,7 @@ public char[] mp3FilesGetPath(int n) {
   }
   return null;
 }
+
 
 // MP3フォルダ内にあるファイルの総数を返す（最大30ファイルまで対応）
 public int mp3FilesGetTotalNum() {

--- a/os/app/mp3Files.cmm
+++ b/os/app/mp3Files.cmm
@@ -108,7 +108,7 @@ public void mp3FilesSetToFnames(char[][] playListSongs) {
   }
 
   int i = 0;
-  while (playListSongs[i][0] != '+') {
+  while (i < MAX_FILE && playListSongs[i][0] != '\0' && playListSongs[i][0] != '+') {
     strCpy(fnames[i], playListSongs[i]);
     i = i + 1;
   }

--- a/os/app/playList.cmm
+++ b/os/app/playList.cmm
@@ -29,7 +29,7 @@
 #define LIST_NUM 10 //プレイリストは10個で固定する
 #define MAX_LIST 50
 
-char[][] playList = array(50, 13); // 1つのプレイリストに登録できる最大曲数は仮に50曲
+char[][] playList = array(50, 13);                   // 1つのプレイリストに登録できる最大曲数は仮に50曲
 char[][] mp3Files = array(50, 13);
 char[][] canAddSongs = array(50, 13);
 
@@ -42,6 +42,7 @@ char[] list_path = array(18);
 char[] ch_buf = array(2);                           // ファイルから読み込む1文字＋終端記号
 int[] line_num = array(LIST_NUM);                  // プレイリストの登録されている曲数を保持する配列
 int addNum = 0;
+int nowIdx = 0;
 
 char[] fnameToPath(char[] fname) {
   strCpy(path, playlistDir);
@@ -60,7 +61,6 @@ public void playListInit() {
   int i = 0;
   while (i< LIST_NUM && (dir=readDir(fd, "TXT"))!=null) {   // 最大10つファイル名を読む
     strCpy(fnames[i], dir.name);
-    dbgPutStr("Read PlayList\n");
     i = i + 1;
   }
   close(fd);
@@ -109,7 +109,7 @@ public char[] playListGetPath(int n) {
 }
 
 // n番目のLISTnに登録されている曲の一覧を取得
-public void showPlayListSongs(int n) {
+public void showPlayListSongs(int n, boolean isPlus) {  // 第二引数：リストに "+" を含めるかどうか．true なら含めて，false なら除外する
 
   //プレイリストの初期化処理
   for (int i = 0; i < MAX_LIST; i = i+1) {
@@ -141,7 +141,7 @@ public void showPlayListSongs(int n) {
     playList[m][strLen(playList[m])] = '\0';       // 最後に終端記号を入れる．
     line_num[n-1] = m + 1;                         // プレイリストに登録されている曲数を代入する．
   }
-  if (line_num[n-1] != mp3FilesGetTotalNum() && line_num[n-1] < MAX_LIST){     // プレイリストに登録されている曲数がMP3フォルダ直下にある曲数と等しくなければ "+" アイコンを追加
+  if (line_num[n-1] != mp3FilesGetTotalNum() && line_num[n-1] < MAX_LIST && isPlus){     // プレイリストに登録されている曲数がMP3フォルダ直下にある曲数と等しくなければ "+" アイコンを追加
     strCat(playList[line_num[n-1]],"+");
     line_num[n-1] = line_num[n-1] + 1;
   }
@@ -150,7 +150,7 @@ public void showPlayListSongs(int n) {
 
 
 //--------------------!!CAUTION!!-----------------------
-// 必ず showPlayListSongs(int n) を実行してから取得すること！
+// 必ず showPlayListSongs(int n, boolean isPlus) を実行してから取得すること！
 //--------------------!!CAUTION!!-----------------------
 // LISTn に登録されている曲数を返す（'+'も含む要素数である．）
 public int playListSongsGetNum(int n) {
@@ -158,7 +158,7 @@ public int playListSongsGetNum(int n) {
 }
 
 //--------------------!!CAUTION!!-----------------------
-// 必ず showPlayListSongs(int n) を実行してから取得すること！
+// 必ず showPlayListSongs(int n, boolean isPlus) を実行してから取得すること！
 //--------------------!!CAUTION!!-----------------------
 // m 番目のリスト内の n 番目ファイル名を返す（1<=n && n<=line_num[n-1]）
 public char[] playListSongsGetName(int m, int n) {
@@ -169,7 +169,7 @@ public char[] playListSongsGetName(int m, int n) {
 }
 
 //--------------------!!CAUTION!!-----------------------
-// 必ず showPlayListSongs(int n) を実行してから取得すること！
+// 必ず showPlayListSongs(int n, boolean isPlus) を実行してから取得すること！
 //--------------------!!CAUTION!!-----------------------
 // 選択中プレイリスト内の全リストを返す．mp3Files.cmm に渡す配列用の取得関数
 public char[][] playListSongsNametoMp3Files() {
@@ -197,8 +197,6 @@ public void playListAddSongs(int n) {
     }
     if (canAdd && addNum < MAX_LIST) {
       strCpy(canAddSongs[addNum], mp3Files[p]);
-      dbgPutStr(canAddSongs[addNum]);
-      dbgPutStr("\n");
       addNum = addNum + 1;
     }
   }
@@ -252,11 +250,9 @@ public void playListRegisterSongs(int l, int[] addSongs) {
   }
   seek(fp, 0, len);                            // fp を seek させる
   for (int m = 0; m < playListAddSongsNum(); m = m + 1) {
-    int nowIdx = 0;
+    nowIdx = 0;
     if (addSongs[m] == 1) {
       addName = playListAddSongsGetName(m + 1); // 追加するファイル名を格納する
-      dbgPutStr(addName);
-      dbgPutStr("\n");
       while (addName[nowIdx] != '\0') {
         ch_buf[0] = addName[nowIdx];
         ch_buf[1] = '\0';
@@ -270,6 +266,59 @@ public void playListRegisterSongs(int l, int[] addSongs) {
           panic("Error occurred. File write was not finished.\n");
       }
     }
+  }
+  ch_buf[0] = '\0';
+  if (write(fp, ch_buf, 1) < 0) {
+      panic("Error occurred. File write was not finished.\n");
+  }
+  close(fp);
+}
+
+// プレイリスト登録曲の削除
+public void playListDeleteSongs(int a, int[] delSongs) {
+
+  list_path[0] = '\0';             // パスの初期化
+  strCpy(list_path, playlistDir);
+  strCat(list_path, "/");
+  strCat(list_path, fnames[a-1]);
+
+  int dp = remove(list_path);  // 一旦ファイルを消す
+  if (dp < 0) {
+    panic("panic : can't remove file.");
+  }
+
+  int cp = creat(list_path);   // 空のファイルを作成
+  if (cp < 0) {
+    panic("panic : can't creat file.");
+  }
+
+  // delSongs と playlist の中身を照らし合わせて WRITE_MODE で上書きすることで削除を再現する
+  int fp = open(list_path, WRITE_MODE);
+  if (fp < 0) {
+    panic("panic : can't reopen list file in WRITE_MODE.");
+  }
+  for (int i = 0; i < line_num[a-1]; i = i + 1) {
+    nowIdx = 0;
+    if (delSongs[i] == 0) {
+      while (playList[i][nowIdx] != '\0') {
+        ch_buf[0] = playList[i][nowIdx];
+        ch_buf[1] = '\0';
+        if (write(fp, ch_buf, 1) < 0) {
+          panic("Error occurred. File write was not finished.\n");
+        }
+        nowIdx = nowIdx + 1;
+      }
+      dbgPutStr(playList[i]);
+      dbgPutStr("\n");
+      ch_buf[0] = '\n';
+      if (write(fp, ch_buf, 1) < 0) {
+          panic("Error occurred. File write was not finished.\n");
+      }
+    }
+  }
+  ch_buf[0] = '\0';
+  if (write(fp, ch_buf, 1) < 0) {
+      panic("Error occurred. File write was not finished.\n");
   }
   close(fp);
 }

--- a/os/app/playList.cmm
+++ b/os/app/playList.cmm
@@ -34,6 +34,7 @@ char[][] mp3Files = array(50, 13);
 char[][] canAddSongs = array(50, 13);
 
 char[][] fnames = array(10, 13);                     // 12345678.123
+char[] addName = array(13);                          // 8.3 形式に従う
 
 char[] playlistDir = "/playlist";
 char[] path = array(18);                            // /playlist/12345678.123
@@ -111,7 +112,7 @@ public char[] playListGetPath(int n) {
 public void showPlayListSongs(int n) {
 
   //プレイリストの初期化処理
-  for (int i = 0; i < LIST_NUM; i = i+1) {
+  for (int i = 0; i < MAX_LIST; i = i+1) {
     playList[i][0] = '\0';
   }
 
@@ -132,7 +133,6 @@ public void showPlayListSongs(int n) {
       m = m + 1;
     } else {
         strCat(playList[m], ch_buf);                // １文字ずつ文字列を連結する．
-        dbgPutStr("char read\n");
     }
   }
   if (playList[m][0] == '\0') {
@@ -197,6 +197,8 @@ public void playListAddSongs(int n) {
     }
     if (canAdd && addNum < MAX_LIST) {
       strCpy(canAddSongs[addNum], mp3Files[p]);
+      dbgPutStr(canAddSongs[addNum]);
+      dbgPutStr("\n");
       addNum = addNum + 1;
     }
   }
@@ -219,4 +221,55 @@ public char[] playListAddSongsGetName(int n) {
     return canAddSongs[n-1];
   }
   return null;
+}
+
+// プレイリストファイルに新たな曲を末尾に登録する．
+public void playListRegisterSongs(int l, int[] addSongs) {
+
+  list_path[0] = '\0';             // パスの初期化
+  strCpy(list_path, playlistDir);
+  strCat(list_path, "/");
+  strCat(list_path, fnames[l-1]);
+  
+  // 一旦 read モードで fp を EOF まで移動させる
+  int fp = open(list_path, READ_MODE);
+  if (fp < 0) {
+    panic("panic : can't open list file READ_MODE. The error occurred.");
+  }
+
+  int len = 0;
+  char[] buf = malloc(1);
+  while (read(fp, buf, 1) > 0) {
+    len = len + 1;
+  }
+  free(buf);
+  close(fp);
+
+  // 追記モードでファイルを開き，EOF までのバイト数 len だけ fp を seek させる
+  fp = open(list_path, APPEND_MODE);
+  if (fp < 0) {
+    panic("panic : can't reopen list file in APPEND_MODE.");
+  }
+  seek(fp, 0, len);                            // fp を seek させる
+  for (int m = 0; m < playListAddSongsNum(); m = m + 1) {
+    int nowIdx = 0;
+    if (addSongs[m] == 1) {
+      addName = playListAddSongsGetName(m + 1); // 追加するファイル名を格納する
+      dbgPutStr(addName);
+      dbgPutStr("\n");
+      while (addName[nowIdx] != '\0') {
+        ch_buf[0] = addName[nowIdx];
+        ch_buf[1] = '\0';
+        if (write(fp, ch_buf, 1) < 0) {
+          panic("Error occurred. File write was not finished.\n");
+        }
+      nowIdx = nowIdx + 1;
+      }
+      ch_buf[0] = '\n';
+      if (write(fp, ch_buf, 1) < 0) {
+          panic("Error occurred. File write was not finished.\n");
+      }
+    }
+  }
+  close(fp);
 }

--- a/os/app/playList.cmm
+++ b/os/app/playList.cmm
@@ -308,8 +308,6 @@ public void playListDeleteSongs(int a, int[] delSongs) {
         }
         nowIdx = nowIdx + 1;
       }
-      dbgPutStr(playList[i]);
-      dbgPutStr("\n");
       ch_buf[0] = '\n';
       if (write(fp, ch_buf, 1) < 0) {
           panic("Error occurred. File write was not finished.\n");

--- a/os/app/playList.hmm
+++ b/os/app/playList.hmm
@@ -38,3 +38,4 @@ public char[][] playListSongsNametoMp3Files();
 public void playListAddSongs(int n);
 public int playListAddSongsNum();
 public char[] playListAddSongsGetName(int n);
+public void playListRegisterSongs(int m, int[] addSongs);

--- a/os/app/playList.hmm
+++ b/os/app/playList.hmm
@@ -31,7 +31,7 @@
 public void playListInit();               // プレイリストの初期化
 public char[] playListGetName(int n);
 public char[] playListGetPath(int n);
-public void showPlayListSongs(int n);
+public void showPlayListSongs(int n, boolean isPlus);
 public int playListSongsGetNum(int n);
 public char[] playListSongsGetName(int m, int n);
 public char[][] playListSongsNametoMp3Files();
@@ -39,3 +39,4 @@ public void playListAddSongs(int n);
 public int playListAddSongsNum();
 public char[] playListAddSongsGetName(int n);
 public void playListRegisterSongs(int m, int[] addSongs);
+public void playListDeleteSongs(int a, int[] delSongs);

--- a/os/app/screenState.cmm
+++ b/os/app/screenState.cmm
@@ -10,7 +10,9 @@ char[][] screenTitles = {
     "CONTRAST",
     "PLAYLIST",
     "PLAYLIST SONGS",
-    "ADD SONGS"
+    "ADD SONGS",
+    "DELETE SONGS",
+    "SORT SONGS"
 };
 
 // 各画面のメニュー項目（stateごとにメニューの文字列配列を持つ）
@@ -23,20 +25,27 @@ char[][][] screenMenuItems = {
     { "UP", "DOWN"},
     { "", "", "", "", "", ""}, //リスト表示画面
     { "", "", "", "", "", ""}, //曲表示画面
-    { "", "", "", "", "", ""} //曲表示画面
+    { "", "", "", "", "", ""}, //曲表示画面
+    { "", "", "", "", "", ""},
+    { "", "", "", "", "", ""}
 };
 
-// 各画面のメニュー項目数（！！曲数は動的なので，項目数は1画面に表示できる最大数とすること！！）
+// 各画面のメニュー項目数
+//------------!!CAUTION!!--------------
+// 動的な項目数をもつ場合は「0」とすること！
+//------------!!CAUTION!!--------------
 int[] screenNumItems = {
     2,
-    6, 
+    0, 
     6,
     2,
     2,
     2,
-    6,
-    6,
-    6
+    0,
+    0,
+    0,
+    0,
+    0
 };
 
 // 初期化処理
@@ -54,9 +63,8 @@ public char[][] getScreenMenuItems(int state) {
 }
 
 // 各画面にメニューリストを入れる
-public void setScreenMenuItems(int state, char[][] items, int count) {
+public void setScreenMenuItems(int state, char[][] items) {
     screenMenuItems[state] = items;
-    screenNumItems[state] = count;
 }
 
 // 各画面の項目数を取得

--- a/os/app/screenState.hmm
+++ b/os/app/screenState.hmm
@@ -30,6 +30,6 @@
 public void initScreens();
 public char[] getScreenTitle(int state);
 public char[][] getScreenMenuItems(int state);
-public void setScreenMenuItems(int state, char[][] items, int count);
+public void setScreenMenuItems(int state, char[][] items);
 public int getScreenNumItems(int state);
 public void setScreenTitle(int state, char[] title);

--- a/os/app/shellProc.cmm
+++ b/os/app/shellProc.cmm
@@ -55,7 +55,9 @@
 #define SWS 0x3f                                    // スイッチのビット全部
 
 //------------------------------------------------------------------------------------------------------------------------------------------------
-//画面ごとの番号定義 0:ホーム　1：曲一覧　2：再生画面　3：オプション　4：音量調整　5：コントラスト調整　6.プレイリスト　7.プレイリストの登録曲表示　8.プレイリストの曲追加
+//画面ごとの番号定義 
+// 0:ホーム　1：曲一覧　2：再生画面　3：オプション　4：音量調整　5：コントラスト調整　6.プレイリスト　7.プレイリストの登録曲表示　8.プレイリストの曲追加
+// 9:プレイリストの曲削除　10:プレイリストの曲順序入れ替え
 //------------------------------------------------------------------------------------------------------------------------------------------------
 #define HOME_STATE 0
 #define MUSIC_STATE 1
@@ -66,6 +68,8 @@
 #define PLAYLIST_STATE 6
 #define PLAYLIST_SONGS 7
 #define PLAYLIST_ADDSONGS 8
+#define PLAYLIST_DELETESONGS 9
+#define PLAYLIST_SORTSONGS 10
 //------------------------------------------------------------------------------------------------------------------------------------------------
 
 #define MAX_LIST 6
@@ -78,6 +82,7 @@ char[][] playList_add;
 int[] prevcursor = array(15);                       // カーソル情報を保持する変数
 int[] prevupper = array(15);                        // 画面最上のインデクスを保持する変数
 int[] addSongsIdx = array(50);
+int[] delSongsIdx = array(50);
 
 int sw0 = 0x00;                                     // 前回の状態(デバウンス前)
 int sw1 = 0x00;
@@ -87,6 +92,9 @@ int shuffleMode = 0;                                //シャッフル管理関�
 int [] shuffleList;                                 //シャッフルリスト
 int shuffleIndex = 0;                               //シャッフル再生中のインデックス
 int list_upper = 0;
+int listNum = 0;                                    // 選択されたプレイリスト番号の保持
+int elementNum = 0;                                 // 表示する要素数の保持
+int numItems = 0;
 
 int readSw() {
   int sw = ~in(0x18) & SWS;                         // スイッチを読み正論理に変換
@@ -122,14 +130,25 @@ public void getAddIdxFromLcd() {
   addSongsIdx = getAllAddIdx();
 }
 
+//-----------------------------------------
+//プレイリスト追加する曲の"-"情報の保持
+//-----------------------------------------
+public void getDelIdxFromLcd() {
+  delSongsIdx = getAllDelIdx();
+}
+
 //画面を表示する関数
 void showScreen(int state, int cursorPos) {
     cls();
     locateXY(0, 0);
     putStr(getScreenTitle(state));
 
-    int numItems = getScreenNumItems(state);
+    numItems = getScreenNumItems(state);
     char[][] menuItems = getScreenMenuItems(state);
+
+    if (numItems == 0) {
+      numItems = elementNum;
+    }
 
     for (int i = 0; i < numItems; i=i+1) {
         locateXY(1, i + 1);
@@ -169,6 +188,18 @@ void showScreen(int state, int cursorPos) {
         }
       }
     }
+    else if (state == PLAYLIST_DELETESONGS) {
+      getDelIdxFromLcd();
+      for (int i = 0; i < 6; i = i + 1) {  // 最大表示行
+        int idx = i + list_upper + 1;
+        if (idx >= 1 && idx <= playListSongsGetNum(listNum)) {
+          if (delSongsIdx[idx-1] == 1) {
+            locateXY(3, i + 1);  // (x=3, y=i+1)
+            putStr("-");
+          }
+        }
+      }
+    }
   }
 
 //-----------------------------------------
@@ -177,11 +208,13 @@ void showScreen(int state, int cursorPos) {
 void malloc_musiclist(int upper_idx){
   musicList = malloc(MAX_LIST * 4);
     int i = 0;
+    elementNum = 0;
     while (i < MAX_LIST) {
       musicList[i] = malloc(NAME_LEN);
       char[] fname = mp3FilesGetName(i + upper_idx + 1);
       if (fname != null) {
         strCpy(musicList[i], fname);
+        elementNum = elementNum + 1;
       } else {
         musicList[i][0] = '\0';
       }
@@ -207,11 +240,13 @@ void free_musiclist(){
 void malloc_playlist(int upper_idx){
   playList = malloc(MAX_LIST * 4);
     int i = 0;
+    elementNum = 0;
     while (i < MAX_LIST) {
       playList[i] = malloc(NAME_LEN);
       char[] fname = playListGetName(i + upper_idx + 1);
       if (fname != null) {
         strCpy(playList[i], fname);
+        elementNum = elementNum + 1;
       } else {
         playList[i][0] = '\0';
       }
@@ -237,11 +272,13 @@ void free_playlist(){
 void malloc_playlist_register(int list_idx, int upper_idx){
   playList_register = malloc(MAX_LIST * 4);
     int i = 0;
+    elementNum = 0;
     while (i < MAX_LIST) {
       playList_register[i] = malloc(NAME_LEN);
       char[] fname = playListSongsGetName(list_idx, upper_idx + i + 1);
       if (fname != null) {
         strCpy(playList_register[i], fname);
+        elementNum = elementNum + 1;
       } else {
         playList_register[i][0] = '\0';
       }
@@ -267,11 +304,13 @@ void free_playlist_register(){
 void malloc_playlist_add(int list_idx){
   playList_add = malloc(MAX_LIST * 4);
     int i = 0;
+    elementNum = 0;
     while (i < MAX_LIST) {
       playList_add[i] = malloc(NAME_LEN);
       char[] fname = playListAddSongsGetName(list_idx + i + 1);
       if (fname != null) {
         strCpy(playList_add[i], fname);
+        elementNum = elementNum + 1;
       } else {
         playList_add[i][0] = '\0';
       }
@@ -325,8 +364,7 @@ public void shellMain() {
   int cursorPos = 0;
   int music_idx = 0;
   int total = 0;
-  int listNum = 0; //選択されたプレイリスト番号を保持する．
-  int songNum = 0;
+  int idx = 0;
 
   showScreen(state, cursorPos);
 
@@ -337,8 +375,11 @@ public void shellMain() {
     int filenum = mp3FilesGetTotalNum(); //MP3ファイルの総数
 
     if (num == 1) {  // SW1 = 上
-      int numItems = getScreenNumItems(state);
-
+      numItems = getScreenNumItems(state);
+      // ステートによってカーソルの範囲を指定する（静的，動的なものを仕分ける）
+      if (numItems == 0) {
+        numItems = elementNum;
+      }
       // カーソルがまだ上に動かせる
       if (cursorPos > 0) {
         cursorPos = cursorPos - 1;
@@ -348,7 +389,7 @@ public void shellMain() {
           list_upper = list_upper - 1;
           free_musiclist();
           malloc_musiclist(list_upper);
-          setScreenMenuItems(state, musicList, MAX_LIST);
+          setScreenMenuItems(state, musicList);
         }
       } else if (state == PLAYLIST_STATE){
         //プレイリスト画面で，かつ上端まで来たときの処理
@@ -356,7 +397,7 @@ public void shellMain() {
           list_upper = list_upper - 1;
           free_playlist();
           malloc_playlist(list_upper);
-          setScreenMenuItems(state, playList, MAX_LIST);
+          setScreenMenuItems(state, playList);
         }
       } else if (state == PLAYLIST_SONGS && playListSongsGetNum(listNum) > 6) {
         //プレイリスト登録曲一覧画面で，かつカーソルが上端まできたときの処理
@@ -364,15 +405,22 @@ public void shellMain() {
           list_upper = list_upper - 1;
           free_playlist_register();
           malloc_playlist_register(listNum, list_upper);
-          setScreenMenuItems(state, playList_register, MAX_LIST);
+          setScreenMenuItems(state, playList_register);
         }
-      }else if (state == PLAYLIST_ADDSONGS && playListAddSongsNum() > 6) {
+      } else if (state == PLAYLIST_ADDSONGS && playListAddSongsNum() > 6) {
         //プレイリストの曲追加画面で，かつ上端まで来たときの処理
         if (cursorPos == 0 && list_upper > 0) {
           list_upper = list_upper - 1;
           free_playlist_add();
           malloc_playlist_add(list_upper);
-          setScreenMenuItems(state, playList_add, MAX_LIST);
+          setScreenMenuItems(state, playList_add);
+        }
+      } else if ((state == PLAYLIST_DELETESONGS || state == PLAYLIST_SORTSONGS) && numItems < playListSongsGetNum(listNum)) {
+        if (cursorPos == 0 && list_upper > 0) {
+          list_upper = list_upper - 1;
+          free_playlist_register();
+          malloc_playlist_register(listNum, list_upper);
+          setScreenMenuItems(state, playList_register);
         }
       } else {
         // 項目数が6以下のとき：ループ処理
@@ -383,8 +431,11 @@ public void shellMain() {
         showScreen(state, cursorPos);
     }
     else if (num == 5) {  // SW5 = 下
-      int numItems = getScreenNumItems(state);
-
+      numItems = getScreenNumItems(state);
+      // ステートによってカーソルの範囲を指定する（静的，動的なものを仕分ける）
+      if (numItems == 0) {
+        numItems = elementNum;
+      }
       // カーソルがまだ下に動かせる
       if (cursorPos + 1 < numItems) {
         cursorPos = cursorPos + 1;
@@ -394,7 +445,7 @@ public void shellMain() {
           list_upper = list_upper + 1;
           free_musiclist();
           malloc_musiclist(list_upper);
-          setScreenMenuItems(state, musicList, MAX_LIST);
+          setScreenMenuItems(state, musicList);
         }
       } else if (state == PLAYLIST_STATE) {
         //プレイリスト画面で，かつ下端まで来たときのスクロール処理
@@ -402,15 +453,15 @@ public void shellMain() {
           list_upper = list_upper + 1;
           free_playlist();
           malloc_playlist(list_upper);
-          setScreenMenuItems(state, playList, MAX_LIST);
+          setScreenMenuItems(state, playList);
         }
-      } else if (state == PLAYLIST_SONGS && playListSongsGetNum(listNum) > 6) {
+      } else if ((state == PLAYLIST_SONGS) && playListSongsGetNum(listNum) > 6 ) {
         //プレイリストの曲一覧画面で，かつカーソルが下端まで来たときのスクロール処理
         if (cursorPos + list_upper < playListSongsGetNum(listNum) - 1) {
           list_upper = list_upper + 1;
           free_playlist_register();
           malloc_playlist_register(listNum, list_upper);
-          setScreenMenuItems(state, playList_register, MAX_LIST);
+          setScreenMenuItems(state, playList_register);
         }
       } else if (state == PLAYLIST_ADDSONGS && playListAddSongsNum() > 6) {
         //曲追加画面で，かつカーソルが下端まで来たときのスクロール処理
@@ -418,10 +469,17 @@ public void shellMain() {
           list_upper = list_upper + 1;
           free_playlist_add();
           malloc_playlist_add(list_upper);
-          setScreenMenuItems(state, playList_add, MAX_LIST);
+          setScreenMenuItems(state, playList_add);
         }
-      }
-      else {
+      } else if((state == PLAYLIST_DELETESONGS || state == PLAYLIST_SORTSONGS) && numItems < playListSongsGetNum(listNum)) { 
+        // PLAYLIST_SONGS のときに要素数が7で，かつ list_upper!=0 の場合の挙動に対応
+        if (cursorPos + list_upper < playListSongsGetNum(listNum) - 1) {
+          list_upper = list_upper + 1;
+          free_playlist_register();
+          malloc_playlist_register(listNum, list_upper);
+          setScreenMenuItems(state, playList_register);
+        }
+      } else {
         //下端→上端ループ
         cursorPos = 0;
         list_upper = 0;
@@ -437,7 +495,7 @@ public void shellMain() {
         if (cursorPos + 1 == 1) {
           mp3FilesInit();                                         // playList で格納した fnames の影響を解消するため
           malloc_musiclist(list_upper);
-          setScreenMenuItems(MUSIC_STATE, musicList, MAX_LIST);
+          setScreenMenuItems(MUSIC_STATE, musicList);
           prevState = state;
           state = MUSIC_STATE;
           cursorPos = 0;
@@ -450,7 +508,7 @@ public void shellMain() {
           state = PLAYLIST_STATE;
           int numlist = getScreenNumItems(state);
           malloc_playlist(list_upper);
-          setScreenMenuItems(state, playList, numlist);
+          setScreenMenuItems(state, playList);
           showScreen(state, cursorPos);
         }
       }
@@ -577,17 +635,12 @@ public void shellMain() {
       else if (state == PLAYLIST_STATE) {
         mp3FilesInit();                                       // 戻るボタンを押したときに発生するバグの解消
         listNum = cursorPos +  list_upper + 1;
-        showPlayListSongs(listNum);
-        if (playListSongsGetNum(listNum) <= MAX_LIST) {
-          songNum = playListSongsGetNum(listNum);
-        } else {
-          songNum = MAX_LIST;
-        }
+        showPlayListSongs(listNum, true);
         list_upper = 0;
         malloc_playlist_register(listNum, list_upper);
         prevState = state;
         state = PLAYLIST_SONGS;
-        setScreenMenuItems(state, playList_register, songNum);
+        setScreenMenuItems(state, playList_register);
         cursorPos = 0;
         showScreen(state, cursorPos);
       }
@@ -597,16 +650,11 @@ public void shellMain() {
           // いまのカーソル位置（cursorPos + list_upper）が "+"なら曲を追加する
           mp3FilesInit();                                       
           playListAddSongs(listNum); // 追加可能な曲のリストを作成する
-          if (playListAddSongsNum() <= MAX_LIST) {
-            songNum = playListAddSongsNum();
-          } else {
-            songNum = MAX_LIST;
-          }
           list_upper = 0;
           malloc_playlist_add(list_upper);
           prevState = state;
           state = PLAYLIST_ADDSONGS;
-          setScreenMenuItems(state, playList_add, songNum);
+          setScreenMenuItems(state, playList_add);
           cursorPos = 0;
           addIdxInit();
           showScreen(state, cursorPos);
@@ -629,11 +677,19 @@ public void shellMain() {
         }
       }
       else if (state == PLAYLIST_ADDSONGS) {
-        int idx = cursorPos + list_upper + 1;
+        idx = cursorPos + list_upper + 1;
         if (getAddIdx(idx) == 0) {
           showAddSongs(cursorPos, idx);
         } else {
           showAddSongsClear(cursorPos, idx);
+        }
+      }
+      else if (state == PLAYLIST_DELETESONGS) {
+        idx = cursorPos + list_upper + 1;
+        if (getDelIdx(idx) == 0) {
+          showDelSongs(cursorPos, idx);
+        } else {
+          showDelSongsClear(cursorPos, idx);
         }
       }
     }
@@ -680,6 +736,7 @@ public void shellMain() {
         state = PLAYLIST_STATE;
         cursorPos = prevcursor[state];
         list_upper = prevupper[state];
+        malloc_playlist(list_upper);
         showScreen(state, cursorPos);
       }
       else if (state == PLAYLIST_ADDSONGS) {
@@ -689,18 +746,52 @@ public void shellMain() {
         cursorPos = prevcursor[state];
         list_upper = prevupper[state];
         free_playlist_register();
-        showPlayListSongs(listNum);
+        showPlayListSongs(listNum, true);
         malloc_playlist_register(listNum, list_upper); // プレイリスト追加の変更反映
-        if (playListSongsGetNum(listNum) <= MAX_LIST) {
-          songNum = playListSongsGetNum(listNum);
-        } else {
-          songNum = MAX_LIST;
-        }
-        setScreenMenuItems(state, playList_register, songNum);
+        setScreenMenuItems(state, playList_register);
+        showScreen(state, cursorPos);
+      }
+      else if (state == PLAYLIST_DELETESONGS) {
+        playListDeleteSongs(listNum, delSongsIdx);
+        free_playlist_register();
+        state = PLAYLIST_STATE;
+        cursorPos = prevcursor[state];
+        list_upper = prevupper[state];
+        malloc_playlist(list_upper);
         showScreen(state, cursorPos);
       }
     }
-
+    else if (num == 4) { // SW4 = プレイリストの編集モード
+      if (state == PLAYLIST_SONGS) {
+        delIdxInit();
+        state = PLAYLIST_DELETESONGS;
+        showPlayListSongs(listNum, false);        // "+" を表示させない
+        free_playlist_register();
+        malloc_playlist_register(listNum, list_upper);
+        if (cursorPos + list_upper >= playListSongsGetNum(listNum)) {
+          cursorPos = cursorPos - 1;
+        }
+        setScreenMenuItems(state, playList_register);
+        showScreen(state, cursorPos);
+      } else if (state == PLAYLIST_DELETESONGS) {
+        state = PLAYLIST_SORTSONGS;
+        showPlayListSongs(listNum, false);       // "+" を表示させない
+        free_playlist_register();
+        malloc_playlist_register(listNum, list_upper);
+        if (cursorPos + list_upper >= playListSongsGetNum(listNum)) {
+          cursorPos = cursorPos - 1;
+        }
+        setScreenMenuItems(state, playList_register);
+        showScreen(state, cursorPos);
+      } else if (state == PLAYLIST_SORTSONGS) {
+        state = PLAYLIST_SONGS;
+        showPlayListSongs(listNum, true);       // PLAYLIST_SONGS に遷移するときは "+" を表示させる
+        free_playlist_register();
+        malloc_playlist_register(listNum, list_upper);
+        setScreenMenuItems(state, playList_register);
+        showScreen(state, cursorPos);
+      }
+    }
     else if (num == 6) { // SW6 = OPTION 画面の出入り
       if (state == VOLUME_STATE || state == CONTRAST_STATE) {
         state = prevState;

--- a/os/app/shellProc.cmm
+++ b/os/app/shellProc.cmm
@@ -77,6 +77,7 @@ char[][] playList_register;
 char[][] playList_add;
 int[] prevcursor = array(15);                       // カーソル情報を保持する変数
 int[] prevupper = array(15);                        // 画面最上のインデクスを保持する変数
+int[] addSongsIdx = array(50);
 
 int sw0 = 0x00;                                     // 前回の状態(デバウンス前)
 int sw1 = 0x00;
@@ -85,6 +86,7 @@ int repeatMode = 0;                                 //リピート管理変数
 int shuffleMode = 0;                                //シャッフル管理関数
 int [] shuffleList;                                 //シャッフルリスト
 int shuffleIndex = 0;                               //シャッフル再生中のインデックス
+int list_upper = 0;
 
 int readSw() {
   int sw = ~in(0x18) & SWS;                         // スイッチを読み正論理に変換
@@ -111,6 +113,13 @@ int swToNum(int sw) {
     num = 1;
   }
   return num;
+}
+
+//-----------------------------------------
+//プレイリスト追加する曲の"+"情報の保持
+//-----------------------------------------
+public void getAddIdxFromLcd() {
+  addSongsIdx = getAllAddIdx();
 }
 
 //画面を表示する関数
@@ -146,6 +155,18 @@ void showScreen(int state, int cursorPos) {
         showRepeatAll();
       } else if (shuffleMode == 1) {
         showShuffleTrue();
+      }
+    }
+    else if (state == PLAYLIST_ADDSONGS) {
+      getAddIdxFromLcd();
+      for (int i = 0; i < 6; i = i + 1) {  // 最大表示行
+        int idx = i + list_upper + 1;
+        if (idx >= 1 && idx <= playListAddSongsNum()) {
+          if (addSongsIdx[idx-1] == 1) {
+            locateXY(3, i + 1);  // (x=3, y=i+1)
+            putStr("+");
+          }
+        }
       }
     }
   }
@@ -213,12 +234,12 @@ void free_playlist(){
 //-----------------------------------------
 //プレイリスト登録曲のメモリ確保
 //-----------------------------------------
-void malloc_playlist_register(int list_idx){
+void malloc_playlist_register(int list_idx, int upper_idx){
   playList_register = malloc(MAX_LIST * 4);
     int i = 0;
     while (i < MAX_LIST) {
       playList_register[i] = malloc(NAME_LEN);
-      char[] fname = playListSongsGetName(list_idx, i + 1);
+      char[] fname = playListSongsGetName(list_idx, upper_idx + i + 1);
       if (fname != null) {
         strCpy(playList_register[i], fname);
       } else {
@@ -304,7 +325,6 @@ public void shellMain() {
   int cursorPos = 0;
   int music_idx = 0;
   int total = 0;
-  int list_upper = 0; //リスト表示される要素の最上のインデクスを保持する．
   int listNum = 0; //選択されたプレイリスト番号を保持する．
   int songNum = 0;
 
@@ -343,7 +363,7 @@ public void shellMain() {
         if (cursorPos == 0 && list_upper > 0) {
           list_upper = list_upper - 1;
           free_playlist_register();
-          malloc_playlist_register(list_upper);
+          malloc_playlist_register(listNum, list_upper);
           setScreenMenuItems(state, playList_register, MAX_LIST);
         }
       }else if (state == PLAYLIST_ADDSONGS && playListAddSongsNum() > 6) {
@@ -389,7 +409,7 @@ public void shellMain() {
         if (cursorPos + list_upper < playListSongsGetNum(listNum) - 1) {
           list_upper = list_upper + 1;
           free_playlist_register();
-          malloc_playlist_register(list_upper);
+          malloc_playlist_register(listNum, list_upper);
           setScreenMenuItems(state, playList_register, MAX_LIST);
         }
       } else if (state == PLAYLIST_ADDSONGS && playListAddSongsNum() > 6) {
@@ -563,12 +583,12 @@ public void shellMain() {
         } else {
           songNum = MAX_LIST;
         }
-        malloc_playlist_register(listNum);
+        list_upper = 0;
+        malloc_playlist_register(listNum, list_upper);
         prevState = state;
         state = PLAYLIST_SONGS;
         setScreenMenuItems(state, playList_register, songNum);
         cursorPos = 0;
-        list_upper = 0;
         showScreen(state, cursorPos);
       }
       else if (state == PLAYLIST_SONGS) {
@@ -582,12 +602,13 @@ public void shellMain() {
           } else {
             songNum = MAX_LIST;
           }
+          list_upper = 0;
           malloc_playlist_add(list_upper);
           prevState = state;
           state = PLAYLIST_ADDSONGS;
           setScreenMenuItems(state, playList_add, songNum);
           cursorPos = 0;
-          list_upper = 0;
+          addIdxInit();
           showScreen(state, cursorPos);
         }
         else {
@@ -605,7 +626,14 @@ public void shellMain() {
             cursorPos = 0;
             showScreen(state, cursorPos);
           }
-
+        }
+      }
+      else if (state == PLAYLIST_ADDSONGS) {
+        int idx = cursorPos + list_upper + 1;
+        if (getAddIdx(idx) == 0) {
+          showAddSongs(cursorPos, idx);
+        } else {
+          showAddSongsClear(cursorPos, idx);
         }
       }
     }
@@ -655,10 +683,20 @@ public void shellMain() {
         showScreen(state, cursorPos);
       }
       else if (state == PLAYLIST_ADDSONGS) {
+        playListRegisterSongs(listNum, addSongsIdx);
         free_playlist_add();
         state = PLAYLIST_SONGS;
         cursorPos = prevcursor[state];
         list_upper = prevupper[state];
+        free_playlist_register();
+        showPlayListSongs(listNum);
+        malloc_playlist_register(listNum, list_upper); // プレイリスト追加の変更反映
+        if (playListSongsGetNum(listNum) <= MAX_LIST) {
+          songNum = playListSongsGetNum(listNum);
+        } else {
+          songNum = MAX_LIST;
+        }
+        setScreenMenuItems(state, playList_register, songNum);
         showScreen(state, cursorPos);
       }
     }


### PR DESCRIPTION
PLAYLIST SONGS から "+" を選択することで ADD SONGS へ遷移，SW2 を押すごとに "+" の表示切替を行います．
SW4 で戻ると，"+" で選択された曲をプレイリストに一括追加します．
追加できる曲がなくなると，PLAYLIST SONGS に "+" を表示せず，ADD SONGS に遷移しません．

これと同時に，いくつかの不具合の修正を行っています．
- PlayList.cmm showPlayListSongs 関数で，PlayListの初期化範囲を誤っていたので修正しました．
- MP3files.cmm mp3FilesSetToFnames 関数で，読み込み判定が"+"までとなっていたので，全曲追加したときの無限ループを修正しました．
- shellProc.cmm malloc_playlist_register 関数の引数を1つ増やし，正しい範囲の要素を取得するように修正しました．
- shellProc.cmm 画面遷移で情報のやり取りが正しくできるように，関数の呼び出し順序を変更しました．