### PR TITLE
設定データのファイルの読み書き，微小な不具合の修正

### DIFF
--- a/os/app/lcd.cmm
+++ b/os/app/lcd.cmm
@@ -47,6 +47,15 @@ char[] locateCom = { '\xb0',   // page address
                      '\x00',   // column address Lo = 0x00
                      '\xff' }; // EOF
 
+char[][] time = {   // スリープまでの時間の表示用
+  "  10",
+  "  30",
+  "  60",
+  " 180",
+  " 300",
+  "None"
+};
+
 int locateX;
 int locateY;
 int dx;
@@ -291,5 +300,15 @@ public void putSleepClown() {
     locateY = 3;
     dy = -1;
     newClown = !newClown;
+  }
+}
+
+public void showSleepTime(int idx) {
+
+  locateXY(5,4);
+  putStr(time[idx]);  // 設定秒数の表示
+
+  if (idx != 5) {
+    putStr(" sec");   // None でなければ，単位を表示させる．
   }
 }

--- a/os/app/lcd.hmm
+++ b/os/app/lcd.hmm
@@ -52,3 +52,4 @@ public void showCrown(int m, int n);
 public void showTime(int n);
 public void initSleepCrown(int sd);
 public void putSleepClown();
+public void showSleepTime(int idx);

--- a/os/app/option.cmm
+++ b/os/app/option.cmm
@@ -1,9 +1,30 @@
 #include "spi.hmm"
 #include "option.hmm"
+#include "lcd.hmm"
 #include "mm.hmm"
+#include <fs.hmm>
+#include <util.hmm>
+#include "appUtil.hmm"
 
-int contrastLevel = 5;
-int volumeLevel = 5;
+int contrastLevel;
+int volumeLevel;
+int sleepTimeIdx;
+
+char[] fname = "setting.txt";           // ファイル名は固定
+char[] path = array(21);                // /settings/setting.txt
+char[] settingsDir = "/settings";
+char[][] settingsData = array(3,3);         // 設定データを保持する配列
+char[] ch_buf = array(2);               // 読み取りデータの一時的な変数
+char[] tmp = array(3);
+char[] dg = array(2);
+int[] time = {10,30,60,180,300,-1};    // -1 は NONE
+
+char[] fnameToPath(char[] fname) {
+  strCpy(path, settingsDir);
+  strCat(path, "/");
+  strCat(path, fname);
+  return path;
+}
 
 void setContrast(int level) { //コントラスト反映
   if (level < 1) level = 1;
@@ -23,7 +44,7 @@ void setContrast(int level) { //コントラスト反映
 
 public void updateContrast(int cursor) {  //コントラスト調整
   if (cursor == 0) {
-    setContrast(contrastLevel + 1);
+    setContrast(contrastLevel + 1);     //set関数が呼ばれたら consrastLebel は更新されている
   } else if (cursor == 1) {
     setContrast(contrastLevel - 1);
   }
@@ -52,4 +73,174 @@ public void updateVolume(int cursor) {
 
 public int getVolumeLevel() {
   return volumeLevel;
+}
+
+public int getSleepTimeIdx() {
+  return sleepTimeIdx;
+}
+
+void setSleepTimeIdx(int idx) {
+  if (idx < 0) {
+    idx = 0;            // 負のインデクスにはさせない．
+  }
+  if (idx >= 5) {
+    idx = 5;            // インデクスをオーバーさせない．
+  }
+  sleepTimeIdx = idx;   // 更新後のインデクスを代入する．
+  showSleepTime(idx);   // lcd に更新後のインデクスを渡す．
+}
+
+public void updateSleepTimeIdx(int cursor) {
+  if (cursor == 0) {
+    setSleepTimeIdx(sleepTimeIdx + 1);
+  } else if (cursor == 1) {
+    setSleepTimeIdx(sleepTimeIdx - 1);
+  }
+}
+
+// char 型配列を int に変換する関数．1から3桁の整数に対応．
+int charToInt(int idx) {
+  int m = strLen(settingsData[idx]) - 1;           //  対象の設定データの桁数から，1の位のインデクスを計算
+  int result = 0;
+  
+  while (true) {
+    
+    // 1 の位の計算
+    result = result + (ord(settingsData[idx][m]) - ord ('0')) * 1;
+    if (m-1 < 0) break;                           // 1 の位みならば抜ける
+    m = m - 1;
+
+    // 10 の位の計算
+    result = result + (ord(settingsData[idx][m]) - ord ('0')) * 10;
+    break;
+  }
+  return result;
+}
+
+
+
+
+// 設定ファイルの初期化を行う．なければ作る．あれば設定を読み出してくる．
+public void initSettings() {
+  int fd;                                           // ファイルディスクリプタ
+  if ((fd=open(settingsDir, READ_MODE))<0) {
+   mkDir(settingsDir);                              // フォルダがなければつくる
+   creat(fnameToPath(fname));                       // フォルダがなければファイルがあるはずがないのでファイルも作る
+   contrastLevel = 5;                               // 初期値を与える
+   volumeLevel = 5;                                 // 初期値を与える
+   sleepTimeIdx = 1;                                  // 初期値は 30 秒にするのでインデクスは1
+  } else {
+    int fp = open(fnameToPath(fname), READ_MODE);   // 設定ファイルを読む
+    if (fp < 0) {
+    panic("panic : can't open settings file. The error occurred.");
+    }
+
+    int line = 0;                                   // いまの行数を示すインデクス
+    // EOF が来るまでファイルを読み込む
+    while (read(fp, ch_buf, 1) != 0) {
+      ch_buf[1] = '\0';
+      if (ch_buf[0] == 0x0a) {                      // もし改行だったら一つの要素の入力は終わり
+        settingsData[line][strLen(settingsData[line])] = '\0';
+        line = line + 1;
+        if (line >= 3) {
+          break;                                    // スリープ時間の設定まで呼んだらループを抜ける
+        }
+      } else {
+        strCat(settingsData[line], ch_buf);         // settingsData にデータを入れる
+      }
+    }
+    // データの読み込みが終わったら int 型に変換して変数に書き込む．
+    //----------------------------------------------------
+    // 0行目：音量　1行目：コントラスト　2行目：スリープまでの時間
+    //----------------------------------------------------
+    volumeLevel = charToInt(0);
+    contrastLevel = charToInt(1);
+    sleepTimeIdx = charToInt(2);
+    // ここで読み込む
+    //-----------------------------------------------------
+
+    close(fp); 
+  }
+  close(fd); 
+
+  // ファイルあり，なしの場合も spi に値を渡して初期化処理を終了する．sleepTime は spi に渡さず，ShellProc にわたす．
+  setVolume(volumeLevel);
+  setContrast(contrastLevel);
+  setSleepTimeIdx(sleepTimeIdx);
+}
+
+// int 型の値を char 型に変換して settingsData にいれる．
+void intToChar(int data, int idx) {
+  
+  int digit;
+  if (data / 10 != 0) { // データが 2桁かどうか？
+    digit = 1;
+  } else { // ここまでくるとデータは 1 桁である．
+    digit = 0;
+  }
+  
+  // データリストの初期化
+  settingsData[idx][0] = '\0';
+  tmp[0] = '\0';
+
+  while(true) {
+    dg[0] = chr(0x30 + data % 10);
+    dg[1] = '\0';
+    // 1 の位を入れ込む
+    strCat(tmp, dg);
+    if (digit - 1 < 0) {  // 1 桁だったら終端記号を入れてループを抜ける
+      break;
+    }
+    digit = digit - 1;
+
+    // 10 の位の入れ込む
+    data = data / 10;
+    dg[0] = chr(0x30 + data % 10);
+    dg[1] = '\0';
+    strCat(tmp, dg);
+    break;
+  }
+  // tmp に逆順で格納されているので，逆にしてもとに戻す
+  for (int i = 0; i < strLen(tmp); i = i + 1) {
+    dg[0] = tmp[strLen(tmp) - i - 1];
+    dg[1] = '\0';
+    strCat(settingsData[idx],dg);
+  }
+}
+
+// 各変数の値をファイルに書き込む．設定画面から抜けたときにファイルに書き込めばよいだろう．
+public void writeSettingsData() {
+
+  // まずは今の各種設定値を文字列に変換する
+  intToChar(volumeLevel, 0);
+  intToChar(contrastLevel, 1);
+  intToChar(sleepTimeIdx, 2);
+
+  // ファイルオープン
+  int fp = open(path, WRITE_MODE);
+   if (fp < 0) {
+    panic("panic : can't open setting file in WRITE_MODE.");
+  }
+
+  // ファイルへの設定値の書き込み
+  for (int i = 0; i < 3; i = i + 1) {
+    int idx = 0;
+    while (settingsData[i][idx] != '\0') {
+      ch_buf[0] = settingsData[i][idx];
+      ch_buf[1] = '\0';
+      if (write(fp, ch_buf, 1) < 0) {
+        panic("Error occurred. File write was not finished.\n");
+      }
+      idx = idx + 1;
+    }
+    ch_buf[0] = '\n';                 //  改行の書き込み
+    if (write(fp, ch_buf, 1) < 0) {
+        panic("Error occurred. File write was not finished.\n");
+    }
+  }
+  ch_buf[0] = '\0';                   // 終端記号の書き込み
+  if (write(fp, ch_buf, 1) < 0) {
+        panic("Error occurred. File write was not finished.\n");
+  }
+  close(fp);
 }

--- a/os/app/option.cmm
+++ b/os/app/option.cmm
@@ -128,7 +128,10 @@ public void initSettings() {
    creat(fnameToPath(fname));                       // フォルダがなければファイルがあるはずがないのでファイルも作る
    contrastLevel = 5;                               // 初期値を与える
    volumeLevel = 5;                                 // 初期値を与える
-   sleepTimeIdx = 1;                                  // 初期値は 30 秒にするのでインデクスは1
+   sleepTimeIdx = 1;                                // 初期値は 30 秒にするのでインデクスは1
+
+   // 設定を変更せずにリセットするとエラーになるのでここでファイルに書き込み動作を行う
+   writeSettingsData();
   } else {
     int fp = open(fnameToPath(fname), READ_MODE);   // 設定ファイルを読む
     if (fp < 0) {

--- a/os/app/option.hmm
+++ b/os/app/option.hmm
@@ -2,3 +2,7 @@ public void updateContrast(int cursor);
 public int getContrastLevel();
 public void updateVolume(int cursor);
 public int getVolumeLevel();
+public int getSleepTimeIdx();
+public void initSettings();
+public void updateSleepTimeIdx(int cursor);
+public void writeSettingsData();

--- a/os/app/playList.cmm
+++ b/os/app/playList.cmm
@@ -143,6 +143,10 @@ public void showPlayListSongs(int n, boolean isPlus) {  // 第二引数：リス
     playList[m][strLen(playList[m])] = '\0';       // 最後に終端記号を入れる．
     line_num[n-1] = m + 1;                         // プレイリストに登録されている曲数を代入する．
   }
+
+  // -------------------------------------------!!CAUTION!!-------------------------------------------------
+  // mp3FilesGetTotalNum() の扱いには注意すること．プレイリスト ⇔ 曲再生 で mp3FilesInit() を実行したか確認すること．
+  // -------------------------------------------!!CAUTION!!-------------------------------------------------
   if (line_num[n-1] != mp3FilesGetTotalNum() && line_num[n-1] < MAX_LIST && isPlus){     // プレイリストに登録されている曲数がMP3フォルダ直下にある曲数と等しくなければ "+" アイコンを追加
     strCat(playList[line_num[n-1]],"+");
     line_num[n-1] = line_num[n-1] + 1;

--- a/os/app/screenState.cmm
+++ b/os/app/screenState.cmm
@@ -17,7 +17,8 @@ char[][] screenTitles = {
     "SORT SONGS",
     "CHOOSE INS PLACE",
     "   MP3 PLAYER",
-    ""
+    "",
+    "SLEEP TIME"
 };
 
 // 各画面のメニュー項目（stateごとにメニューの文字列配列を持つ）
@@ -25,7 +26,7 @@ char[][][] screenMenuItems = {
     { "1: MUSIC", "2: PLAYLIST" },  // ホーム画面
     { "", "", "", "", "", ""},  //曲選択画面
     { "PLAY", "PAUSE", "NEXT", "PREV", "REPEAT", "SHUFFLE"},  //曲再生画面
-    { "VOLUME", "CONTRAST"},  //オプション画面
+    { "VOLUME", "CONTRAST", "SLEEP TIME"},  //オプション画面
     { "UP", "DOWN"},
     { "UP", "DOWN"},
     { "", "", "", "", "", ""}, //リスト表示画面
@@ -35,7 +36,8 @@ char[][][] screenMenuItems = {
     { "", "", "", "", "", ""},
     { "", "", "", "", "", ""},
     { "", "", "", "", "", ""},
-    { "", "", "", "", "", ""}
+    { "", "", "", "", "", ""},
+    { "UP", "DOWN"}
 };
 
 // 各画面のメニュー項目数
@@ -46,7 +48,7 @@ int[] screenNumItems = {
     2,
     0, 
     6,
-    2,
+    3,
     2,
     2,
     0,
@@ -56,12 +58,9 @@ int[] screenNumItems = {
     0,
     0,
     6,
-    0
+    0,
+    2
 };
-
-// 初期化処理
-public void initScreens() {
-}
 
 // 各画面のタイトルを取得
 public char[] getScreenTitle(int state) {

--- a/os/app/screenState.hmm
+++ b/os/app/screenState.hmm
@@ -27,7 +27,7 @@
  */
 
 
-public void initScreens();
+
 public char[] getScreenTitle(int state);
 public char[][] getScreenMenuItems(int state);
 public void setScreenMenuItems(int state, char[][] items);

--- a/os/app/shellProc.cmm
+++ b/os/app/shellProc.cmm
@@ -74,6 +74,7 @@
 #define PLAYLIST_SORTFINDINSERT 11
 #define OPENING 12
 #define SLEEP_STATE 13
+#define SLEEP_OPTION_STATE 14
 //------------------------------------------------------------------------------------------------------------------------------------------------
 
 #define MAX_LIST 6
@@ -107,6 +108,7 @@ int elementNum = 0;                                 // 表示する要素数の�
 int numItems = 0;
 int stateidx = 0;                                   // 画面遷移のインデクスを保持するための変数
 int seed = 0;
+int[] time = {10,30,60,180,300,-1};                 // 無操作状態でスリープ状態に遷移するまでの時間（単位：s）
 
 int readSw() {
   int sw = ~in(0x18) & SWS;                         // スイッチを読み正論理に変換
@@ -195,6 +197,9 @@ void showScreen(int state, int cursorPos) {
     }
     else if (state == VOLUME_STATE) {
       showLevelBar(getVolumeLevel());
+    }
+    else if (state == SLEEP_OPTION_STATE) {
+      showSleepTime(getSleepTimeIdx());
     }
     else if (state == MUSIC_INF) {
       if (repeatMode == 1) {
@@ -440,12 +445,13 @@ void free_shuffleList() {
 //-----------------------------------------------------------------------------
 // ここからプロセスの実行が始まる
 public void shellMain() {
-  spiResetLcd();  // sleepを使用するので
+  spiResetLcd();   // sleepを使用するので
   cls();
-  spiResetMp3();  //   プロセスが実行する
+  spiResetMp3();   //   プロセスが実行する
   mp3FilesInit();  // ファイル一覧を作る
-  playListInit(); // プレイリストの一覧を作る
-  initScreens();
+  playListInit();  // プレイリストの一覧を作る
+  initSettings();  // 設定データの読み込み
+  int sleeptime = time[getSleepTimeIdx()]; // スリープ状態に遷移するまでの時間の設定
 
 // ----------------------------------------------
 // オープニング画面の表示
@@ -494,7 +500,6 @@ public void shellMain() {
   int idx = 0;
   int status;
   int lastShownSec = -1;
-  int sleeptime = 10;
   int sleepFrame = 0;
   int silentFrames = 0;
   boolean justWokeUpFromSleep = false;
@@ -524,9 +529,9 @@ public void shellMain() {
       continue;
     }
 
-    if (playing_status() == 0 && num == -1) {
+    if (playing_status() == 0 && num == -1 && sleeptime > 0) {
       silentFrames = silentFrames + 1;
-    } else if (playing_status() == 1) {
+    } else if (playing_status() == 1 || num!=-1) {
       // 曲が明らかに再生中なら silentFrames をリセット
       silentFrames = 0;
     }
@@ -865,6 +870,11 @@ public void shellMain() {
           cursorPos = 0;
           showScreen(state, cursorPos);
         }
+        else if (cursorPos == 2) {  // スリープまでの時間設定
+          state = SLEEP_OPTION_STATE;
+          cursorPos = 0;
+          showScreen(state, cursorPos);
+        }
       }
       else if (state == VOLUME_STATE) {
         if (cursorPos == 0) {
@@ -881,6 +891,15 @@ public void shellMain() {
           showScreen(state, cursorPos);
         } else if (cursorPos == 1) {  // DOWN
           updateContrast(cursorPos);
+          showScreen(state, cursorPos);
+        }
+      }
+      else if (state == SLEEP_OPTION_STATE) {
+        if (cursorPos == 0) {
+          updateSleepTimeIdx(cursorPos);
+          showScreen(state, cursorPos);
+        } else if (cursorPos == 1) {
+          updateSleepTimeIdx(cursorPos);
           showScreen(state, cursorPos);
         }
       }
@@ -983,11 +1002,19 @@ public void shellMain() {
       else if (state == MUSIC_INF) {
         if (prevState[stateidx] == MUSIC_STATE) {
           state = MUSIC_STATE;
+          cursorPos = prevcursor[state];
+          list_upper = prevupper[state];
         } else {
           state = PLAYLIST_SONGS;
+          cursorPos = prevcursor[state];
+          list_upper = prevupper[state];
+          mp3FilesInit();
+          showPlayListSongs(listNum, true);
+          free_playlist_register();
+          malloc_playlist_register(listNum, list_upper);
+          setScreenMenuItems(state, playList_register);
         }
-        cursorPos = prevcursor[state];
-        list_upper = prevupper[state];
+        
         removeChangeScreen();
         showScreen(state, cursorPos);
       }
@@ -1001,6 +1028,13 @@ public void shellMain() {
         state = OPTION_STATE;
         cursorPos = prevcursor[state];
         list_upper = prevupper[state];
+        showScreen(state, cursorPos);
+      }
+      else if (state == SLEEP_OPTION_STATE){
+        state = OPTION_STATE;
+        cursorPos = prevcursor[state];
+        list_upper = prevupper[state];
+        sleeptime = time[getSleepTimeIdx()];  // スリープまでの時間更新
         showScreen(state, cursorPos);
       }
       else if (state == PLAYLIST_STATE) {
@@ -1108,11 +1142,13 @@ public void shellMain() {
       }
     }
     else if (num == 6) { // SW6 = OPTION 画面の出入り
-      if (state == VOLUME_STATE || state == CONTRAST_STATE || state == OPTION_STATE) {
+      if (state == VOLUME_STATE || state == CONTRAST_STATE || state == OPTION_STATE || state == SLEEP_OPTION_STATE) {
         state = prevState[stateidx];      // 前の画面に戻るために履歴から state を呼び出す
         removeChangeScreen();             // 前の画面の情報を消す
         cursorPos = prevcursor[state];
         list_upper = prevupper[state];
+        sleeptime = time[getSleepTimeIdx()]; // sleep時間変更画面から直接戻った場合の変更を反映する．
+        writeSettingsData();              // 設定データのファイルへの書き込み
         showScreen(state, cursorPos);
       } else { //OPTION画面に入る．
         saveChangeScreen(state);         // option 前の画面情報を保持する


### PR DESCRIPTION
設置値をファイルから読み書きする仕様に変更しました．
起動時に設定値の初期化を行い，設定ファイルが存在しなければファイルを作成し，適当な初期値を与えます．
ファイルが存在すれば，ファイルから設定値を読み込んで初期化を行っています．
設定値を変更すると，設定画面から抜けた際にファイルに設定値を書き込むようになっています．
なお，スリープまでの時間は 10秒，30秒，60秒，180秒，300秒，なし の6段階の設定方式としています．

さらに，微小な不具合を修正しました．playlist_songs から曲を再生し，SW2 で戻ってモード切替を1周すると "+" が消える現象を修正しました．