### PR TITLE
曲再生中のnext,prev操作における再生時間の表示ミスの修正

### DIFF
--- a/os/app/shellProc.cmm
+++ b/os/app/shellProc.cmm
@@ -784,15 +784,18 @@ public void shellMain() {
           }
           char[] nextTitle = mp3FilesGetName(music_idx);
           if (nextTitle != null) {
-            setScreenTitle(MUSIC_INF, nextTitle);
-            showScreen(state, cursorPos);
             char[] path = mp3FilesGetPath(music_idx);
             strCpy(tmp,path);
             if (status == 1) {
+              timerStop();
+              lastShownSec = -1;
               play(path);
+              strCpy(nowpath,path);
               timerStart(TIMER_MODE_PLAYBACK);
             }
           }
+          setScreenTitle(MUSIC_INF, nextTitle);
+          showScreen(state, cursorPos);
         }
         else if (cursorPos == 3) {  // PREV 選択
           status = playing_status();
@@ -816,15 +819,18 @@ public void shellMain() {
           }
           char[] prevTitle = mp3FilesGetName(music_idx);
           if (prevTitle != null) {
-            setScreenTitle(MUSIC_INF, prevTitle);
-            showScreen(state, cursorPos);
             char[] path = mp3FilesGetPath(music_idx);
             strCpy(tmp,path);
             if (status == 1) {
+              timerStop();
+              strCpy(nowpath,path);
+              lastShownSec = -1;
               play(path);
               timerStart(TIMER_MODE_PLAYBACK);
             }
           }
+          setScreenTitle(MUSIC_INF, prevTitle);
+          showScreen(state, cursorPos);
         }
         else if (cursorPos == 4) { //REPEAT選択
           repeatMode = (repeatMode + 1) % 3;


### PR DESCRIPTION
曲再生中，つまり state == 1 のときに nowpath をコピーすることをうっかり忘れていました．